### PR TITLE
Fixes socketry/db-postgres#6 - Parsing of timestamps with microsecond precison

### DIFF
--- a/lib/db/postgres/native/types.rb
+++ b/lib/db/postgres/native/types.rb
@@ -99,12 +99,16 @@ module DB
 					attr :name
 					
 					def parse(string)
-						if match = string.match(/(\d+)-(\d+)-(\d+) (\d+):(\d+):(\d+)([\+\-].*)?/)
-							parts = match.captures
-							parts[6] ||= "UTC"
-							
-							return Time.new(*parts)
+						return nil unless match = string.match(/\A(\d+)-(\d+)-(\d+) (\d+):(\d+):(\d+(?:\.\d+)?)([-+].*)?\z/)
+						parts = match.captures
+						parts[5] = BigDecimal(parts[5])
+						if parts[6].nil?
+							parts[6] = '+00:00'
+						elsif /^[-+]\d\d$/ === parts[6]
+							parts[6] += ':00'
 						end
+
+						Time.new(*parts)
 					end
 				end
 				


### PR DESCRIPTION
Fixes socketry/db-postgres#6
Postgres can return timestamps with microsecond precision, and `db-postgres` is failing to handle these well.

This is an attempt to fix that behaviour.

Notes:
- An invalid timestamp will return a `nil` (as before), but maybe an explicit raise would be better?
- Ruby <= 2.6 couldn't handle a timezone of `UTC` - only `+HH:MM` format
- Ruby <= 2.6 can't handle timezones in `+HH` format (i.e. optional minutes)
- Ruby <= 2.5 can handle microsecond precision, but typically hides it when testing in `irb` :/

## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).

I tested with the following values (collected from Postgres):
```ruby
strings = [
    "2022-01-02 12:13:14",
    "2022-01-02 12:13:14-11",
    "2018-09-02 03:39:19+04:30",
    "2020-09-25 03:16:48.648682+00",
    "2022-01-02 12:13:14.123456",
    "2022-01-02 12:13:14.123456+08"
]
```
And I tested in Ruby 2.3 -> 3.1