### PR TITLE
Fixes socketry/db-postgres#6 - Timestamp parsing: microseconds, time-zones, infinity and NULL

### DIFF
--- a/lib/db/postgres/native/types.rb
+++ b/lib/db/postgres/native/types.rb
@@ -99,16 +99,21 @@ module DB
 					attr :name
 					
 					def parse(string)
-						return nil unless match = string.match(/\A(\d+)-(\d+)-(\d+) (\d+):(\d+):(\d+(?:\.\d+)?)([-+].*)?\z/)
-						parts = match.captures
-						parts[5] = BigDecimal(parts[5])
-						if parts[6].nil?
-							parts[6] = '+00:00'
-						elsif /^[-+]\d\d$/ === parts[6]
-							parts[6] += ':00'
+						case string
+						when '-infinity', 'infinity', nil
+							string
+						when /\A(\d+)-(\d+)-(\d+) (\d+):(\d+):(\d+(?:\.\d+)?)([-+]\d\d(?::\d\d)?)?\z/
+							parts = $~.captures
+							parts[5] = BigDecimal(parts[5])
+							if parts[6].nil?
+								parts[6] = '+00:00'
+							elsif /^[-+]\d\d$/ === parts[6]
+								parts[6] += ':00'
+							end
+							Time.new(*parts)
+						else
+							raise "Invalid TIMESTAMP: #{string}"
 						end
-
-						Time.new(*parts)
 					end
 				end
 				

--- a/lib/db/postgres/native/types.rb
+++ b/lib/db/postgres/native/types.rb
@@ -99,12 +99,16 @@ module DB
 					attr :name
 					
 					def parse(string)
-						if match = string.match(/(\d+)-(\d+)-(\d+) (\d+):(\d+):(\d+)([\+\-].*)?/)
-							parts = match.captures
-							parts[6] ||= "UTC"
-							
-							return Time.new(*parts)
+						return nil unless match = string.match(/\A(\d+)-(\d+)-(\d+) (\d+):(\d+):(\d+(?:\.\d+)?)([-+].*)?\z/)
+						parts = match.captures
+						parts[5] = BigDecimal(parts[5])
+						if parts[6].nil?
+							parts[6] = '+00:00'
+						elsif /^[-+]\d\d$/ === parts[6]
+							parts[6] += ':00'
 						end
+
+						Time.new(*parts)
 					end
 				end
 				

--- a/spec/db/postgres/connection_spec.rb
+++ b/spec/db/postgres/connection_spec.rb
@@ -98,10 +98,31 @@ RSpec.describe DB::Postgres::Connection do
 			zone: 'Asia/Kolkata',
 			time: '2000-01-01 00:00:00+00',
 			result: Time.new(2000, 1, 1, 5, 30, 0, '+05:30'),
+		}, {
+			# PG produces: "infinity"
+			zone: 'UTC',
+			time: 'infinity',
+			result: 'infinity',
+		}, {
+			# PG produces: "-infinity"
+			zone: 'UTC',
+			time: '-infinity',
+			result: '-infinity',
+		}, {
+			# PG produces: null
+			zone: 'UTC',
+			time: nil,
+			result: nil,
 		}].each do |spec|
 
-			connection.send_query("SET TIME ZONE '#{spec[:zone]}'");
-			connection.send_query("SELECT '#{spec[:time]}'::TIMESTAMPTZ AS TS")
+			connection.send_query("SET TIME ZONE '#{spec[:zone]}'")
+
+			buffer = String.new
+			buffer << "SELECT "
+			connection.append_literal(spec[:time], buffer)
+			buffer << "::TIMESTAMPTZ"
+
+			connection.send_query buffer
 
 			result = connection.next_result
 			row = result.to_a.first


### PR DESCRIPTION
Same as PR socketry/db-postgres#7, but includes explicit handling of `infinity`, `-infinity` and NULLs. Anything else causes an exception (instead of silently coercing the value to a `nil`)

I've kept it as a separate PR because these are significant changes.

## Types of Changes

- Bug fix.
- Breaking change.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
