### PR TITLE
Try `Time.new(string, in: 0)` for parsing.

### DIFF
--- a/lib/db/postgres/native/types.rb
+++ b/lib/db/postgres/native/types.rb
@@ -88,17 +88,7 @@ module DB
 							return string
 						end
 						
-						if match = string.match(/\A(\d+)-(\d+)-(\d+) (\d+):(\d+):(\d+(?:\.\d+)?)([-+]\d\d(?::\d\d)?)?\z/)
-							parts = match.captures
-							
-							parts[5] = Rational(parts[5])
-							
-							if parts[6].nil?
-								parts[6] = '+00'
-							end
-							
-							return Time.new(*parts)
-						end
+						return Time.new(string, in: 0)
 					end
 				end
 				


### PR DESCRIPTION
Newer versions of Ruby include support for `Time.new(string)` for parsing. We might need to wait until support for Ruby 3.1 is dropped, as this feature was introduced in 3.2+.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
