### PR TITLE
Expose PQSendQueryParams and handle bytea data type

### DIFF
--- a/lib/db/postgres/connection.rb
+++ b/lib/db/postgres/connection.rb
@@ -101,6 +101,12 @@ module DB
 				@native.send_query(statement)
 			end
 			
+			def send_query_params(statement, *params)
+				@native.discard_results
+				
+				@native.send_query_params(statement, *params)
+			end
+			
 			def next_result
 				@native.next_result
 			end

--- a/lib/db/postgres/native/connection.rb
+++ b/lib/db/postgres/native/connection.rb
@@ -187,9 +187,24 @@ module DB
 				end
 				
 				def send_query_params(statement, *params)
+					params = params.map(&:to_s)
 					size = params.size
-					params = Strings.new(params)
-					check! Native.send_query_params(self, statement, size, nil, params.array, nil, nil, 0)
+					is_binary = params.map { |param| param.include?("\x00".b) }
+					
+					# type 17 => bytea (https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.dat)
+					paramTypes = FFI::MemoryPointer.new(:int, params.size)
+					paramTypes.write_array_of_type(FFI::Type::INT, :put_int, is_binary.map { |binary| binary ? 17 : 0 })
+					
+					paramValues = FFI::MemoryPointer.new(:pointer, params.size)
+					paramValues.write_array_of_pointer(params.map { |param| FFI::MemoryPointer.from_string(param) })
+					
+					paramLengths = FFI::MemoryPointer.new(:int, params.size)
+					paramLengths.write_array_of_type(FFI::Type::INT, :put_int, params.zip(is_binary).map { |param, binary| binary ? param.bytesize : 0 })
+					
+					paramFormats = FFI::MemoryPointer.new(:int, params.size)
+					paramFormats.write_array_of_type(FFI::Type::INT, :put_int, is_binary.map { |binary| binary ? 1 : 0 })
+					
+					check! Native.send_query_params(self, statement, size, paramTypes, paramValues, paramLengths, paramFormats, 0)
 					
 					flush
 				end

--- a/lib/db/postgres/native/connection.rb
+++ b/lib/db/postgres/native/connection.rb
@@ -186,6 +186,14 @@ module DB
 					flush
 				end
 				
+				def send_query_params(statement, *params)
+					size = params.size
+					params = Strings.new(params)
+					check! Native.send_query_params(self, statement, size, nil, params.array, nil, nil, 0)
+					
+					flush
+				end
+				
 				def next_result(types: @types)
 					if result = self.get_result
 						status = Native.result_status(result)

--- a/lib/db/postgres/native/field.rb
+++ b/lib/db/postgres/native/field.rb
@@ -40,6 +40,8 @@ module DB
 				# These are hard coded OIDs.
 				16 => Types::Boolean.new,
 				
+				17 => Types::ByteA.new,
+				
 				20 => Types::Integer.new("int8"),
 				21 => Types::Integer.new("int2"),
 				23 => Types::Integer.new("int4"),

--- a/lib/db/postgres/native/types.rb
+++ b/lib/db/postgres/native/types.rb
@@ -44,6 +44,16 @@ module DB
 					end
 				end
 				
+				class ByteA
+					def name
+						"BYTEA"
+					end
+					
+					def parse(string)
+						[string[2..]].pack('H*') if string
+					end
+				end
+				
 				class Decimal
 					def name
 						"DECIMAL"

--- a/test/db/postgres/connection.rb
+++ b/test/db/postgres/connection.rb
@@ -26,6 +26,16 @@ describe DB::Postgres::Connection do
 	ensure
 		connection.close
 	end
+
+	it "should execute query with arguments" do
+		connection.send_query_params("SELECT $1::BIGINT AS LIFE, $2 AS ANSWER", 42, "Life, the universe and everything")
+		
+		result = connection.next_result
+		
+		expect(result.to_a).to be == [[42, "Life, the universe and everything"]]
+	ensure
+		connection.close
+	end
 	
 	it "should execute multiple queries" do
 		connection.send_query("SELECT 42 AS LIFE; SELECT 24 AS LIFE")

--- a/test/db/postgres/connection.rb
+++ b/test/db/postgres/connection.rb
@@ -71,6 +71,17 @@ describe DB::Postgres::Connection do
 		connection.close
 	end
 	
+	it "can handle bytea argument" do
+		connection.send_query_params("SELECT $1::BYTEA", "ABC\x0089".b)
+		
+		result = connection.next_result
+		cell = result.to_a.first.first
+		expect(cell).to be == "ABC\x0089".b
+		expect(cell.encoding).to be == Encoding::ASCII_8BIT
+	ensure
+		connection.close
+	end
+	
 	with '#append_string' do
 		it "should escape string" do
 			expect(connection.append_string("Hello 'World'")).to be == "'Hello ''World'''"

--- a/test/db/postgres/connection.rb
+++ b/test/db/postgres/connection.rb
@@ -60,6 +60,17 @@ describe DB::Postgres::Connection do
 		connection.close
 	end
 	
+	it "can handle bytea output" do
+		connection.send_query("SELECT '\\x414243003839'::BYTEA")
+		
+		result = connection.next_result
+		cell = result.to_a.first.first
+		expect(cell).to be == "ABC\x0089".b
+		expect(cell.encoding).to be == Encoding::ASCII_8BIT
+	ensure
+		connection.close
+	end
+	
 	with '#append_string' do
 		it "should escape string" do
 			expect(connection.append_string("Hello 'World'")).to be == "'Hello ''World'''"


### PR DESCRIPTION
Short description of our use case: We're currently using the `pg` gem with a lot of either hand crafted or generated queries with the postgresql style arguments. This means code like this:
```ruby
dbh.exec('SELECT $1::bigint, $2', 42, 'The anwser')
```
This format is not compatible with the db style placeholders. Instead of having to migrate big bang style, this change exposes `PQSendQueryParams` which can handle this format. This allows us to change the backend from pg to db-postgres and then we can slowly migrate to the db style placeholders.

This change also adds support for the bytea data type (this is kind of connected to the arguments), this might be a backwards incompatible change, where the old code returned a hexdump of the bytea string, which is now returned as a Ruby string with binary encoding.

## Types of Changes

- New feature.
- Breaking change (minor)

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
